### PR TITLE
strings.Trim expects a cutset, not a string

### DIFF
--- a/internal/imports/fix.go
+++ b/internal/imports/fix.go
@@ -444,7 +444,7 @@ func apply(fset *token.FileSet, f *ast.File, fixes []*importFix) bool {
 		case setImportName:
 			// Find the matching import path and change the name.
 			for _, spec := range f.Imports {
-				path := strings.Trim(spec.Path.Value, `""`)
+				path := strings.Trim(spec.Path.Value, `"`)
 				if path == fix.info.importPath {
 					spec.Name = &ast.Ident{
 						Name:    fix.info.name,


### PR DESCRIPTION
strings.Trim treats the second parameter as a set of characters you
want to trim. It does not look for an entire string to trim.

This fix will maintain the current behavior, simply eliminating the dupe
character in the set.

Should we instead mean to really trim the entire string, this needs a
different fix.